### PR TITLE
Resolved BCC address appearing in messages by default.

### DIFF
--- a/Class Library/ActiveUp.Net.Common/Message.cs
+++ b/Class Library/ActiveUp.Net.Common/Message.cs
@@ -542,7 +542,7 @@ namespace ActiveUp.Net.Mail
         /// <returns></returns>
         public string ToMimeString()
         {
-            return ToMimeString(false);
+            return ToMimeString(true);
         }
 
         /// <summary>


### PR DESCRIPTION
Now messages sent with multiple BCCs will not appear visible to recipients.